### PR TITLE
Add multi-spec wishlist support and bump version to 0.2.0

### DIFF
--- a/EasyWishlist/EasyWishlist.toc
+++ b/EasyWishlist/EasyWishlist.toc
@@ -1,7 +1,7 @@
 ## Interface: 120001
 ## Title: EasyWishlist
 ## Notes: Track your best gear upgrades from sim reports
-## Version: 0.1.0
+## Version: 0.2.0
 ## Author: Frostfel
 ## SavedVariables: EasyWishlistDB
 


### PR DESCRIPTION
## What

- Add per-spec storage (v3 data model): each character stores one wishlist per spec, keyed by spec name
- Imports now upsert by itemID — re-importing the same spec updates existing items instead of duplicating
- Add spec dropdown in the UI to switch between specs and delete non-last ones
- Bump version to 0.2.0 and add GitHub Actions release workflow

## Why

Previously only one report could be stored per character, so importing a second spec silently overwrote the first. This release enables players to maintain separate wishlists per spec and switch between them in the addon window.

## How

Data is stored as `{ activeSpec, bySpec = { [specName] = { spec, lastUpdated, results[] } } }`. A `MigrateIfNeeded` function handles transparent migration from v1/v2 saved data on first access.

## Test plan

- [ ] Import a report for spec A, then spec B — verify both are retained
- [ ] Re-import spec A — verify items merge/update, not duplicate
- [ ] Switch specs via dropdown and confirm item list updates
- [ ] Delete a spec (when 2+ exist) and verify remaining spec becomes active
- [ ] Load addon with old v1/v2 saved data and verify migration works without errors
- [ ] Merge to main and verify GitHub Actions release workflow publishes a .zip

## Notes

- The release workflow zips `EasyWishlist/`, generates a changelog from commits since the last tag, and publishes a GitHub release.
- Old saved data (v1/v2 formats) is migrated lazily on first access — no manual migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)