### PR TITLE
Release v0.6.2 — stat filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.2] - 2026-04-15
+
+### Added
+- Secondary stat filters (Haste, Mastery, Crit, Vers) in the item list. Toggle one or more stat buttons to narrow the list to gear that has all selected stats. Stats load in the background and the list updates live as filters are toggled.
+
+### Fixed
+- Stat filter buttons now toggle off correctly when clicked a second time.
+- Stat filters now work on Dragonflight and later clients. `GetItemStats` was removed by Blizzard; the addon now uses `C_TooltipInfo.GetItemByID` to detect secondary stats.
+
+---
+
 ## [0.6.1] - 2026-04-15
 
 ### Fixed

--- a/EasyWishlist/EasyWishlist.toc
+++ b/EasyWishlist/EasyWishlist.toc
@@ -1,7 +1,7 @@
 ## Interface: 120001
 ## Title: EasyWishlist
 ## Notes: Track your best gear upgrades from sim reports
-## Version: 0.6.1
+## Version: 0.6.2
 ## Author: Frostfel
 ## SavedVariables: EasyWishlistDB
 


### PR DESCRIPTION
## What

- First clean release of the secondary stat filter feature
- Consolidates `0.6.0` and `0.6.1` which merged without a GitHub release
- Bumps version to `0.6.2`

## Why

`v0.6.0` and `v0.6.1` were merged but no release was ever generated. This PR cuts the proper release so users on CurseForge/Wago get the update.

## What's included

**Added**
- Stat filter toggle buttons (Haste / Mastery / Crit / Vers) in the item list right panel
- AND logic — selecting multiple stats shows only items that have all selected stats
- Stats load async via `C_TooltipInfo.GetItemByID` and cache per session

**Fixed**
- Toggle buttons now deactivate correctly on second click (Lua ternary bug)
- Filters work on Dragonflight+ clients — `GetItemStats` was removed by Blizzard, replaced with `C_TooltipInfo.GetItemByID` tooltip parsing

## Test plan

- [ ] Stat filter buttons visible below Group buttons
- [ ] Each button toggles on and off correctly
- [ ] Single stat filter narrows list correctly
- [ ] Multiple stat filters apply AND logic
- [ ] Combining stat filter + dungeon filter works
- [ ] No Lua errors on window open

🤖 Generated with [Claude Code](https://claude.com/claude-code)